### PR TITLE
Remove Mar 2 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Tasks and deadlines are tracked using our [planning board](https://github.com/ou
 - [26 Jan, Async Check-in](./notes/2019-01-26-planning-async.md)
 - [02 Feb, 13:00 – 14:00](./notes/2019-02-02-planning-call.md)
 - [09 Feb, 13:00 – 14:00](./notes/2019-02-09-planning-call.md)
-- 02 Mar – [Notepad](https://hackmd.io/thUKLLPMQSan3mRo2d6bGA?edit)
-- 16 Mar –
+- 16 Mar – [Notepad](https://hackmd.io/thUKLLPMQSan3mRo2d6bGA?edit)
 - 30 Mar –
 - 13 Apr –
 - 27 Apr –


### PR DESCRIPTION
Not sure if this is accurate -- but I believe Mar 2 meeting became a review for OAC grant and was cut short. Can I just cut this from the readme? 

I also assume the review sessions were only in the docs, so no notes should be added to the repo. Let me know if I'm wrong!

Best,
Dawn